### PR TITLE
Assets cc mytokenorders optimisations and dust fixes

### DIFF
--- a/src/cc/CCassets.h
+++ b/src/cc/CCassets.h
@@ -42,40 +42,13 @@ uint8_t DecodeAssetTokenOpRetV1(const CScript &scriptPubKey, uint8_t &assetsEval
 vscript_t EncodeAssetOpRetV2(uint8_t assetFuncId, uint256 assetid2, int64_t unit_price, std::vector<uint8_t> origpubkey);
 uint8_t DecodeAssetTokenOpRetV2(const CScript &scriptPubKey, uint8_t &assetsEvalCode, uint256 &tokenid, uint256 &assetid2, int64_t &unit_price, std::vector<uint8_t> &origpubkey);
 
-//uint8_t SetAssetOrigpubkey(std::vector<uint8_t> &origpubkey_out, CAmount &unit_price, const CTransaction &tx);
-//int64_t IsAssetvout(struct CCcontract_info *cp, int64_t &remaining_units_out, std::vector<uint8_t> &origpubkey_out, const CTransaction& tx, int32_t v, uint256 refassetid);
 bool ValidateBidRemainder(CAmount unit_price, int64_t remaining_nValue, int64_t orig_nValue, int64_t received_nValue, int64_t paid_units);
 bool ValidateAskRemainder(CAmount unit_price, int64_t remaining_assetoshis, int64_t orig_assetoshis, int64_t received_assetoshis, int64_t paid_nValue);
 bool ValidateSwapRemainder(int64_t remaining_units, int64_t remaining_nValue, int64_t orig_nValue, int64_t received_nValue, int64_t paidprice, int64_t totalprice);
 bool SetBidFillamounts(CAmount unit_price, int64_t &received_nValue, int64_t orig_nValue, int64_t &paid_units, int64_t orig_units, CAmount paid_unit_price);
 bool SetAskFillamounts(CAmount unit_price, int64_t fill_assetoshis, int64_t orig_assetoshis, int64_t paid_nValue);
 bool SetSwapFillamounts(CAmount unit_price, int64_t &paid, int64_t orig_nValue, int64_t &received, int64_t totalprice); // not implemented
-//int64_t AssetValidateBuyvin(struct CCcontract_info *cp, Eval* eval, int64_t &unit_price, std::vector<uint8_t> &origpubkey_out, char *origCCaddr_out, char *origaddr_out, const CTransaction &tx, uint256 refassetid);
-//int64_t AssetValidateSellvin(struct CCcontract_info *cp, Eval* eval, int64_t &unit_price, std::vector<uint8_t> &origpubkey_out, char *origCCaddr_out, char *origaddr_out, const CTransaction &tx, uint256 assetid);
-//bool AssetsCalcAmounts(struct CCcontract_info *cpAssets, int64_t &inputs, int64_t &outputs, Eval* eval, const CTransaction &tx, uint256 assetid);
-//bool AssetsGetCCInputs(struct CCcontract_info *cpAssets, CAmount &tokensInputs, int64_t &assetsInputs, Eval* eval, const CTransaction &tx, uint256 assetid);
 CAmount AssetsGetCCInputs(struct CCcontract_info *cp, const char *addr, const CTransaction &tx);
-//uint256 AssetsGetPrevOrdertxid(const CTransaction &tx);
-//CAmount AssetsGetUnitPrice(uint256 ordertxid);
-
-// CCassetstx
-//int64_t GetAssetBalance(CPubKey pk,uint256 tokenid); // --> GetTokenBalance()
-//int64_t AddAssetInputs(struct CCcontract_info *cp, CMutableTransaction &mtx, CPubKey pk, uint256 assetid, int64_t total, int32_t maxinputs);
-
-//UniValue AssetOrders(uint256 tokenid, CPubKey pubkey, uint8_t additionalEvalCode);
-//UniValue AssetInfo(uint256 tokenid);
-//UniValue AssetList();
-//std::string CreateAsset(int64_t txfee,int64_t assetsupply,std::string name,std::string description);
-//std::string AssetTransfer(int64_t txfee,uint256 assetid,std::vector<uint8_t> destpubkey,int64_t total);
-//std::string AssetConvert(int64_t txfee,uint256 assetid,std::vector<uint8_t> destpubkey,int64_t total,int32_t evalcode);
-
-//UniValue CreateBuyOffer(const CPubKey &mypk, int64_t txfee, int64_t bidamount, uint256 assetid, int64_t numtokens);
-//UniValue CancelBuyOffer(const CPubKey &mypk, int64_t txfee, uint256 assetid, uint256 bidtxid);
-//UniValue FillBuyOffer(const CPubKey &mypk, int64_t txfee, uint256 assetid, uint256 bidtxid, int64_t fill_units, CAmount paid_unit_price);
-//UniValue CreateSell(const CPubKey &mypk, int64_t txfee, int64_t numtokens, uint256 assetid, int64_t askamount);
-//std::string CreateSwap(int64_t txfee, int64_t askamount, uint256 assetid, uint256 assetid2, int64_t pricetotal);
-//UniValue CancelSell(const CPubKey &mypk, int64_t txfee, uint256 assetid, uint256 asktxid);
-//UniValue FillSell(const CPubKey &mypk, int64_t txfee, uint256 assetid, uint256 assetid2, uint256 asktxid, int64_t fillamount, CAmount paid_unit_price);
 
 const char ccassets_log[] = "ccassets";
 

--- a/src/cc/CCassetsCore_impl.h
+++ b/src/cc/CCassetsCore_impl.h
@@ -100,12 +100,12 @@ int64_t IsAssetvout(struct CCcontract_info *cp, int64_t &remaining_units_out, st
 
 // extract sell/buy owner's pubkey from the opret
 template<class A>
-uint8_t SetAssetOrigpubkey(std::vector<uint8_t> &origpubkey_out, CAmount &unit_price, const CTransaction &tx)
+uint8_t GetOrderParams(std::vector<uint8_t> &origpubkey_out, CAmount &unit_price, uint256 &assetid, const CTransaction &tx)
 {
-    uint256 assetid, assetid2;
+    uint256 assetid2;
     uint8_t evalCode, funcid;
 
-    if (tx.vout.size() > 0 && (funcid = A::DecodeAssetTokenOpRet(tx.vout[tx.vout.size() - 1].scriptPubKey, evalCode, assetid, assetid2, unit_price, origpubkey_out)) != 0)
+    if (tx.vout.size() > 0 && (funcid = A::DecodeAssetTokenOpRet(tx.vout.back().scriptPubKey, evalCode, assetid, assetid2, unit_price, origpubkey_out)) != 0)
         return funcid;
     else
         return 0;

--- a/src/cc/CCtokens.h
+++ b/src/cc/CCtokens.h
@@ -445,7 +445,7 @@ public:
 };
 
 /// @private 
-template <class V> uint8_t ValidateTokenOpret(uint256 txid, const CScript &scriptPubKey, uint256 tokenid);
+//template <class V> uint8_t ValidateTokenOpret(uint256 txid, const CScript &scriptPubKey, uint256 tokenid);
 /// @private 
 template <class V> bool ExtractTokensCCVinPubkeys(const CTransaction &tx, std::vector<CPubKey> &vinPubkeys);
 /// @private 

--- a/src/cc/assets.cpp
+++ b/src/cc/assets.cpp
@@ -19,6 +19,10 @@
 #include "CCassetsCore_impl.h"
 #include "CCNFTData.h"
 
+const int32_t CCVOUT = 1;
+const int32_t NORMALVOUT = 0;
+
+
 /*
  TODO: update:
 
@@ -169,7 +173,7 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
 	uint8_t funcid, evalCodeInOpret; 
 	char destaddr[KOMODO_ADDRESS_BUFSIZE], origNormalAddr[KOMODO_ADDRESS_BUFSIZE], ownerNormalAddr[KOMODO_ADDRESS_BUFSIZE]; 
     char origTokensCCaddr[KOMODO_ADDRESS_BUFSIZE], origCCaddrDummy[KOMODO_ADDRESS_BUFSIZE]; 
-    char tokensDualEvalUnspendableCCaddr[KOMODO_ADDRESS_BUFSIZE], origAssetsCCaddr[KOMODO_ADDRESS_BUFSIZE];
+    char tokensDualEvalUnspendableCCaddr[KOMODO_ADDRESS_BUFSIZE], origAssetsCCaddr[KOMODO_ADDRESS_BUFSIZE], globalAssetsCCaddr[KOMODO_ADDRESS_BUFSIZE];
 
     CAmount vin_tokens = 0;
     CAmount vin_assetoshis = 0;
@@ -180,7 +184,6 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
         
 	if (tx.vout.size() == 0)
 		return eval->Invalid("AssetValidate: no vouts");
-
     if((funcid = A::DecodeAssetTokenOpRet(tx.vout[numvouts-1].scriptPubKey, evalCodeInOpret, assetid, assetid2, unit_price, vorigpubkey)) == 0 )
         return eval->Invalid("AssetValidate: invalid opreturn payload");
 
@@ -210,6 +213,9 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
 
     // originator cc address, this is for marker validation:
     GetCCaddress(cpAssets, origAssetsCCaddr, vorigpubkey, A::IsMixed()); 
+
+    // global cc address:
+    GetCCaddress(cpAssets, globalAssetsCCaddr, GetUnspendable(cpAssets, NULL), A::IsMixed()); 
 
     if( IsCCInput(tx.vin[0].scriptSig) != false )   // vin0 should be normal vin
         return eval->Invalid("illegal asset cc vin0");
@@ -246,12 +252,14 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
                 //preventCCvouts = 2;
                 if (numvouts < 3)
                     return eval->Invalid("too few vouts");
-                else if( A::ConstrainVout(tx.vout[0], 1, cpAssets->unspendableCCaddr, 0LL, A::EvalCode()) == false )
+                else if( A::ConstrainVout(tx.vout[0], CCVOUT, cpAssets->unspendableCCaddr, 0LL, A::EvalCode()) == false )
                     return eval->Invalid("invalid funding for bid");
-                else if( A::ConstrainVout(tx.vout[1], 1, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )       // marker to originator asset cc addr
+                else if( A::ConstrainVout(tx.vout[1], CCVOUT, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )       // marker to originator asset cc addr
                     return eval->Invalid("invalid vout1 marker for original pubkey");
                 else if( TotalPubkeyNormalInputs(tx, pubkey2pk(vorigpubkey)) == 0 ) // check tx is signed by originator pubkey
-                    return eval->Invalid("not the originator pubkey signed");
+                    return eval->Invalid("not the originator pubkey signed for bid");
+                else if (unit_price <= 0)
+                    return eval->Invalid("invalid unit price");
 
                 // check should not be assets cc vins:
                 for (auto const &vin : tx.vin)   {
@@ -272,22 +280,23 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
             //vout.n-1: opreturn [EVAL_ASSETS] ['o']
             ccvins = 2;  // order and marker
             ccvouts = 0;
-            if (vin_assetoshis = AssetValidateBuyvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origCCaddrDummy, origNormalAddr, tx, assetid) == 0)
-                return(false);
+            vin_assetoshis = AssetValidateBuyvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origCCaddrDummy, origNormalAddr, tx, assetid);
+            if (vin_assetoshis == 0)
+                return false;  // eval already set
             
             if (tx.vout[0].nValue > ASSETS_NORMAL_DUST)  {
-                if( A::ConstrainVout(tx.vout[0], 0, origNormalAddr, vin_assetoshis, 0) == false )
+                if (!A::ConstrainVout(tx.vout[0], NORMALVOUT, origNormalAddr, vin_assetoshis, 0))
                     return eval->Invalid("invalid refund for cancelbid");
             } else {
-                bool isCCVout = A::ConstrainVout(tx.vout[0], 1, cpAssets->unspendableCCaddr, vin_assetoshis, 0);
-                if( A::ConstrainVout(tx.vout[0], 0, origNormalAddr, vin_assetoshis, 0) == false &&
+                bool isCCVout = A::ConstrainVout(tx.vout[0], CCVOUT, cpAssets->unspendableCCaddr, vin_assetoshis, 0);
+                if (!A::ConstrainVout(tx.vout[0], NORMALVOUT, origNormalAddr, vin_assetoshis, 0) &&
                     !isCCVout )  // dust allowed to go back
-                    return eval->Invalid("invalid refund for cancelbid");
+                    return eval->Invalid("invalid dust refund for cancelbid");
                 if( isCCVout )
                     ccvouts ++;
             }
-            if( TotalPubkeyNormalInputs(tx, pubkey2pk(vin_origpubkey)) == 0 ) // check tx is signed by originator pubkey
-                return eval->Invalid("not the originator pubkey signed");
+            if (TotalPubkeyNormalInputs(tx, pubkey2pk(vin_origpubkey)) == 0) // check tx is signed by originator pubkey
+                return eval->Invalid("not the originator pubkey signed for cancelbid");
 
             //preventCCvins = 2;
             //preventCCvouts = 0;
@@ -298,82 +307,93 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
             //vin.0: normal input
             //vin.1: cc assets unspendable (vout.0 from buyoffer) buyTx.vout[0]
             //vin.2+: valid CC output satisfies buyoffer (*tx.vin[2])->nValue
-            //vout.0: remaining amount of bid to cc assets global address
+            //vout.0: remaining amount of bid to cc assets global address (if sufficient to buy a token or dust)
             //vout.1: vin.1 value to signer of vin.2
-            //vout.2: vin.2 assetoshis to original pubkey (-royalty)
+            //vout.2: vin.2 satoshi to original pubkey (except royalty if any)
             //vout.3: royalty to token owner (optional)
-            //vout.4: CC output for assetoshis change (if any)
+            //vout.4: CC output for satoshi change (if any)
             //vout.5: normal output for change (if any)
             //vout.n-1: opreturn [EVAL_ASSETS] ['B'] [assetid] [remaining asset required] [origpubkey]
-            //preventCCvouts = 4;
 			ccvins = 1;
-            ccvouts = 3;
-
-            if( (vin_assetoshis = AssetValidateBuyvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid)) == 0 )
-                return false;
-            else if( numvouts < 4 )
+            ccvouts = 0;  // at least tokens output
+            vin_assetoshis = AssetValidateBuyvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid);
+            if (vin_assetoshis == 0)
+                return false;  // eval already set
+            else if( numvouts < 3 )
                 return eval->Invalid("not enough vouts for fillbid");
             else if( vin_origpubkey != vorigpubkey )    // originator pk does not change in the new opret
                 return eval->Invalid("mismatched opreturn originator pubkeys for fillbid");
             else if (unit_price != vin_unit_price)
                 return eval->Invalid("mismatched unit price for fillbid");
+            else if (unit_price <= 0)
+                return eval->Invalid("invalid unit price");
             else
             {
                 int32_t r = royaltyFract > 0 ? 1 : 0;
+
                 CAmount assetoshis = tx.vout[0].nValue + tx.vout[1].nValue + (royaltyFract > 0 ? tx.vout[2].nValue : 0);
                 if( vin_assetoshis != assetoshis )             // coins -> global cc address (remainder) + normal self address
-                    return eval->Invalid("input cc value doesnt match vout0+1" + std::string(royaltyFract > 0 ? "+2" : "") + " for fillbid");
-                
-                vin_tokens = AssetsGetCCInputs(cpTokens, NULL, tx);
-                if( tx.vout[4+r].scriptPubKey.IsPayToCryptoCondition() != false )    // if tokens remainder exists 
-                {
-                    if( A::ConstrainVout(tx.vout[2+r], 1, origTokensCCaddr, 0LL, T::EvalCode()) == false )	// tokens to originator cc addr (tokens+nonfungible evalcode)
-                        return eval->Invalid("vout" + std::to_string(2+r) + " tokens value should go to originator pubkey for fillbid");
-                    else if( vin_tokens != tx.vout[2+r].nValue + tx.vout[4+r].nValue )    // tokens from cc global address -> token global addr (remainder) + originator cc address
-                        return eval->Invalid("tokens inputs doesnt match tokens vout" + std::to_string(2+r) + "+" + "vout"+std::to_string(4+r) + " for fillbid");
-                    //preventCCvouts ++;
-                    ccvouts++;
-                }
-                else if( A::ConstrainVout(tx.vout[2+r], 1, origTokensCCaddr, vin_tokens, T::EvalCode()) == false )   // all tokens to originator cc addr, no cc change present
-                    return eval->Invalid("vout" + std::to_string(2+r) + " should have tokens to originator cc addr for fillbid");
+                    return eval->Invalid("input cc value does not equal to vout0+1" + std::string(royaltyFract > 0 ? "+2" : "") + " for fillbid");
 
-                if( A::ConstrainVout(tx.vout[1], 0, NULL, 0LL, 0) == false )                            // amount paid for tokens goes to normal addr (we can't check 'self' address)
-                    return eval->Invalid("vout1 should be normal for fillbid");
-                else if( A::ConstrainVout(tx.vout[3+r], 1, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )       // marker to originator asset cc addr
-                    return eval->Invalid("invalid vout" + std::to_string(3+r) + " marker for originator pubkey for fillbid");
-                
-                CAmount received_value = royaltyFract > 0 ? tx.vout[1].nValue + tx.vout[2].nValue : tx.vout[1].nValue; // vout1 paid value to seller, vout2 royalty to owner
-                CAmount paid_units = tx.vout[2+r].nValue;
-                if( ValidateBidRemainder(unit_price, tx.vout[0].nValue, vin_assetoshis, received_value, paid_units) == false ) // check real price and coins spending from global addr
-                    return eval->Invalid("vout" + std::to_string(2+r) + " mismatched remainder for fillbid");
-                if (unit_price <= 0)
-                    return eval->Invalid("invalid unit price");
-                if (royaltyFract > 0) {
-                    if ((tx.vout[1].nValue + tx.vout[2].nValue) / NFTROYALTY_DIVISOR * royaltyFract != tx.vout[2].nValue)  // validate royalty value
-                        return eval->Invalid("vout2 invalid royalty amount for fillask");
-                    if( A::ConstrainVout(tx.vout[2], 0, ownerNormalAddr, 0LL, 0) == false )        // validate owner royalty dest
-                        return eval->Invalid("vout2 invalid royalty detination for fillask");
+                // coins remainder
+                if (tx.vout[0].nValue / unit_price > 0 || tx.vout[0].nValue <= ASSETS_NORMAL_DUST)  {
+                    if (!A::ConstrainVout(tx.vout[0], CCVOUT, globalAssetsCCaddr, 0LL, A::EvalCode()))  
+                        return eval->Invalid("invalid vout0 should to global address for fillbid");
+                    ccvouts ++;
                 }
-                if( tx.vout[0].nValue / unit_price != 0 ) // remaining tokens to buy
+                if (tx.vout[0].nValue / unit_price > 0 || tx.vout[0].nValue <= ASSETS_NORMAL_DUST) // there are remaining tokens to buy
                 {
-                    if( A::ConstrainVout(tx.vout[0], 1, cpAssets->unspendableCCaddr, 0LL, A::EvalCode()) == false )  // if remainder sufficient to buy tokens -> coins to asset global cc addr
+                    if (!A::ConstrainVout(tx.vout[0], CCVOUT, globalAssetsCCaddr, 0LL, A::EvalCode()))  // if remainder sufficient to buy tokens -> coins to asset global cc addr
                         return eval->Invalid("mismatched vout0 global assets CC addr for fillbid");
                 }
                 else 
-                {   // remaining_units == 0
-                    if( tx.vout[0].nValue > ASSETS_NORMAL_DUST )  {
-                        if( A::ConstrainVout(tx.vout[0], 0, origNormalAddr, 0LL, 0) == false )  // remainder less than token price should return to originator normal addr
-                            return eval->Invalid("vout0 should be originator normal address with remainder for fillbid");
-                        ccvouts--;
-                    }
-                    else {
-                        bool isCCVout = A::ConstrainVout(tx.vout[0], 1, cpAssets->unspendableCCaddr, 0, 0);
-                        if( A::ConstrainVout(tx.vout[0], 0, origNormalAddr, 0LL, 0) == false &&
-                            !isCCVout ) // dust allowed to go back to cc global addr
-                            return eval->Invalid("vout0 should be originator normal address with remainder or dust should go back to global addr for fillbid");
-                        if( !isCCVout )
-                            ccvouts--;
-                    }
+                {   // if remaining_units == 0 (empty bid) then the remainder should go to the originator normal address (if not dust)
+                    if (!A::ConstrainVout(tx.vout[0], NORMALVOUT, origNormalAddr, 0LL, 0))  // remainder less than token price should return to originator normal addr
+                        return eval->Invalid("vout0 should be originator normal address with remainder for fillbid");
+                }
+
+                vin_tokens = AssetsGetCCInputs(cpTokens, NULL, tx);
+                int32_t myNormalVout = 1;
+                int32_t myTokenVout = 2+r;
+                int32_t tokenRemainderVout; 
+                if (tx.vout[0].nValue / unit_price > 0)
+                    tokenRemainderVout = 4+r;  // marker present before this vout 
+                else
+                    tokenRemainderVout = 3+r;  // no marker
+                
+                if (tx.vout.size() > tokenRemainderVout && tx.vout[tokenRemainderVout].scriptPubKey.IsPayToCryptoCondition())    // if tokens remainder exists 
+                {
+                    if (!A::ConstrainVout(tx.vout[myTokenVout], CCVOUT, origTokensCCaddr, 0LL, T::EvalCode()))	// tokens to originator cc addr (tokens+nonfungible evalcode)
+                        return eval->Invalid("vout" + std::to_string(myTokenVout) + " tokens value should go to originator pubkey for fillbid");
+                    else if (vin_tokens != tx.vout[myTokenVout].nValue + tx.vout[tokenRemainderVout].nValue)    // tokens from cc global address -> token global addr (remainder) + originator cc address
+                        return eval->Invalid("tokens inputs doesnt match tokens vout" + std::to_string(myTokenVout) + "+" + "vout"+std::to_string(tokenRemainderVout) + " for fillbid");
+                    ccvouts += 2;
+                }
+                else {
+                    if (tx.vout.size() <= myTokenVout || !A::ConstrainVout(tx.vout[myTokenVout], CCVOUT, origTokensCCaddr, vin_tokens, T::EvalCode()))   // all tokens to originator cc addr, no cc change present
+                        return eval->Invalid("vout" + std::to_string(myTokenVout) + " should have tokens to originator cc addr for fillbid");
+                    ccvouts ++;
+                }
+
+                if (!A::ConstrainVout(tx.vout[myNormalVout], NORMALVOUT, NULL, 0LL, 0))                            // amount paid for tokens goes to normal addr (we can't check 'self' address)
+                    return eval->Invalid("vout " + std::to_string(myNormalVout) + " should be normal for fillbid");
+
+                if (tx.vout[0].nValue / unit_price > 0)  { // bid coins remainder sufficient for more tokens - marker should exist
+                    int32_t markerVout = 3 + r;
+                    if (tx.vout.size() <= markerVout || !A::ConstrainVout(tx.vout[markerVout], CCVOUT, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()))       // marker to originator asset cc addr
+                        return eval->Invalid("invalid vout" + std::to_string(markerVout) + " marker for originator pubkey for fillbid");
+                    ccvouts ++;
+                }
+                
+                CAmount received_value = royaltyFract > 0 ? tx.vout[1].nValue + tx.vout[2].nValue : tx.vout[1].nValue; // vout1 paid value to seller, vout2 royalty to owner
+                CAmount paid_units = tx.vout[2+r].nValue;
+                if (!ValidateBidRemainder(unit_price, tx.vout[0].nValue, vin_assetoshis, received_value, paid_units)) // check real price and coins spending from global addr
+                    return eval->Invalid("vout" + std::to_string(2+r) + " mismatched remainder for fillbid");
+                if (royaltyFract > 0) {
+                    if ((tx.vout[1].nValue + tx.vout[2].nValue) / NFTROYALTY_DIVISOR * royaltyFract != tx.vout[2].nValue)  // validate royalty value
+                        return eval->Invalid("vout2 invalid royalty amount for fillask");
+                    if (!A::ConstrainVout(tx.vout[2], NORMALVOUT, ownerNormalAddr, 0LL, 0))        // validate owner royalty dest
+                        return eval->Invalid("vout2 invalid royalty detination for fillask");
                 }
             }
             //fprintf(stderr,"fillbuy validated\n");
@@ -398,21 +418,21 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
                 char origTokenAddr[KOMODO_ADDRESS_BUFSIZE];
                 CPubKey origpk = pubkey2pk(vorigpubkey);
 
-                //preventCCvouts = 2;
                 ccvouts = 2;
                 if (numvouts < 3)
                     return eval->Invalid("too few vouts");
-                else if (A::ConstrainVout(tx.vout[0], 1, tokensDualEvalUnspendableCCaddr, 0LL, T::EvalCode()) == false)      // tokens sent to global addr
+                else if (A::ConstrainVout(tx.vout[0], CCVOUT, tokensDualEvalUnspendableCCaddr, 0LL, T::EvalCode()) == false)      // tokens sent to global addr
                     return eval->Invalid("invalid vout0 global two eval address for sell");
-                else if( A::ConstrainVout(tx.vout[1], 1, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )  // marker to originator asset cc addr
+                else if( A::ConstrainVout(tx.vout[1], CCVOUT, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )  // marker to originator asset cc addr
                     return eval->Invalid("invalid vout1 marker for originator pubkey");
                 else if (TotalPubkeyNormalInputs(tx, origpk) == 0)  // check tx is signed by originator pubkey
-                    return eval->Invalid("not the originator pubkey signed");
+                    return eval->Invalid("not the originator pubkey signed for ask");
+                else if (unit_price <= 0)
+                    return eval->Invalid("invalid unit price");
 
-                //GetTokensCCaddress(cpTokens, origTokenAddr, origpk, A::IsMixed());
                 if (tx.vout[2].scriptPubKey.IsPayToCryptoCondition())
                     if (!tx.vout[2].scriptPubKey.IsPayToCCV2() || tx.vout[2].scriptPubKey.SpkHasEvalcodeCCV2(T::EvalCode()))  // have token change
-                        ccvouts ++; //    preventCCvouts ++;
+                        ccvouts ++;
 
                 // check should not be assets cc vins:
                 for (auto const &vin : tx.vin)   {
@@ -430,15 +450,13 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
             //vout.1: vin.2 back to users pubkey
             //vout.2: normal output for change (if any)
             //vout.n-1: opreturn [EVAL_ASSETS] ['x'] [assetid]
-
-            if( (vin_tokens = AssetValidateSellvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid)) == 0 )  
+            vin_tokens = AssetValidateSellvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid);
+            if (vin_tokens == 0)  
                 return false;  // eval already set
-            else if (A::ConstrainVout(tx.vout[0], 1, origTokensCCaddr, vin_tokens, T::EvalCode()) == false)      // tokens returning to originator cc addr
+            else if (A::ConstrainVout(tx.vout[0], CCVOUT, origTokensCCaddr, vin_tokens, T::EvalCode()) == false)      // tokens returning to originator cc addr
                 return eval->Invalid("invalid vout0 for cancelask");
             else if (TotalPubkeyNormalInputs(tx, pubkey2pk(vin_origpubkey)) == 0)  // check tx is signed by originator pubkey
-                return eval->Invalid("not the originator pubkey signed");
-            //preventCCvins = 3;
-            //preventCCvouts = 1;
+                return eval->Invalid("not the originator pubkey signed for cancelask");
             ccvins = 2;  // order and marker
             ccvouts = 1;
             break;
@@ -453,11 +471,11 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
             //vout.3: normal output for change (if any)
             //'S'.vout.n-1: opreturn [EVAL_ASSETS] ['S'] [assetid] [amount of coin still required] [origpubkey]
 			ccvins = 1;
-            ccvouts = 3;
-
-            if( (vin_tokens = AssetValidateSellvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid)) == 0 )
-                return false;  // eval is set
-            else if( numvouts < 4 )
+            ccvouts = 2;
+            vin_tokens = AssetValidateSellvin<A>(cpAssets, eval, vin_unit_price, vin_origpubkey, origTokensCCaddr, origNormalAddr, tx, assetid);
+            if (vin_tokens == 0)
+                return false;  // eval is already set
+            else if( numvouts < 3 )
                 return eval->Invalid("not enough vouts for fillask");
             else if( vin_origpubkey != vorigpubkey )
                 return eval->Invalid("mismatched origpubkeys for fillask");
@@ -465,29 +483,30 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
                 return eval->Invalid("mismatched unit price for fillask");
             else
             {
-                int32_t markerVout = royaltyFract > 0 ? 4 : 3;
-                if( vin_tokens != tx.vout[0].nValue + tx.vout[1].nValue )
+                if (vin_tokens != tx.vout[0].nValue + tx.vout[1].nValue)
                     return eval->Invalid("locked value doesnt match vout0+1 fillask");
 
                 CAmount paid_value = royaltyFract > 0 ? tx.vout[2].nValue+tx.vout[3].nValue : tx.vout[2].nValue; // vout2 paid value to seller, vout3 royalty to owner
-                if( ValidateAskRemainder(unit_price, tx.vout[0].nValue, vin_tokens, tx.vout[1].nValue, paid_value) == false ) 
+                if (!ValidateAskRemainder(unit_price, tx.vout[0].nValue, vin_tokens, tx.vout[1].nValue, paid_value)) 
                     return eval->Invalid("mismatched vout0 remainder for fillask");
-                else if( A::ConstrainVout(tx.vout[1], 1, NULL, 0LL, T::EvalCode()) == false )      // do not check tokens buyer's 'self' cc addr
+                else if (!A::ConstrainVout(tx.vout[1], CCVOUT, NULL, 0LL, T::EvalCode()))      // do not check tokens buyer's 'self' cc addr
                     return eval->Invalid("vout1 should be cc for fillask");
-                else if( A::ConstrainVout(tx.vout[2], 0, origNormalAddr, 0LL, 0) == false )        // coins to originator normal addr
+                else if (!A::ConstrainVout(tx.vout[2], NORMALVOUT, origNormalAddr, 0LL, 0))        // coins to originator normal addr
                     return eval->Invalid("vout2 should be cc for fillask");
                 if (royaltyFract > 0)  {
                     if ((tx.vout[2].nValue + tx.vout[3].nValue) / NFTROYALTY_DIVISOR * royaltyFract != tx.vout[3].nValue)  // validate royalty value
                         return eval->Invalid("vout3 invalid royalty amount for fillask");
-                    if( A::ConstrainVout(tx.vout[3], 0, ownerNormalAddr, 0LL, 0) == false )        // validate owner royalty dest
+                    if (!A::ConstrainVout(tx.vout[3], NORMALVOUT, ownerNormalAddr, 0LL, 0))        // validate owner royalty dest
                         return eval->Invalid("vout3 invalid royalty detination for fillask");
                 }
-                if( A::ConstrainVout(tx.vout[markerVout], 1, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )  // marker to originator asset cc addr
-                    return eval->Invalid("invalid marker vout for original pubkey");
-                else // if( remaining_units != 0 )  // remaining expected amount in coins, should be anyway
-                {
-                    if( A::ConstrainVout(tx.vout[0], 1, tokensDualEvalUnspendableCCaddr, 0LL, A::EvalCode()) == false )   // tokens remainder on global addr
-                        return eval->Invalid("mismatched vout0 two eval global CC addr for fillask");
+                if (!A::ConstrainVout(tx.vout[0], CCVOUT, tokensDualEvalUnspendableCCaddr, 0LL, A::EvalCode()))   // tokens remainder on global addr
+                    return eval->Invalid("invalid vout0 should pay to tokens/assets global address for fillask");
+                if (tx.vout[0].nValue > 0)  {
+                    int32_t markerVout = royaltyFract > 0 ? 4 : 3;
+                    // marker should exist if remainder not empty
+                    if( tx.vout.size() <= markerVout || A::ConstrainVout(tx.vout[markerVout], CCVOUT, origAssetsCCaddr, ASSETS_MARKER_AMOUNT, A::EvalCode()) == false )  // marker to originator asset cc addr
+                        return eval->Invalid("invalid marker vout for original pubkey");
+                    ccvouts ++;
                 }
             }
             
@@ -527,7 +546,7 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
                 else if( tx.vout[3].scriptPubKey.IsPayToCryptoCondition() != false )
 				////////// not implemented yet ////////////
                 {
-                    if( ConstrainVout(tx.vout[2], 1, origTokensCCaddr, 0) == false )
+                    if( ConstrainVout(tx.vout[2], CCVOUT, origTokensCCaddr, 0) == false )
                         return eval->Invalid("vout2 doesnt go to origpubkey fillex");
                     else if( tokens != tx.vout[2].nValue + tx.vout[3].nValue )
                     {
@@ -536,19 +555,19 @@ static bool AssetsValidateInternal(struct CCcontract_info *cp, Eval* eval,const 
                     }
                 }
 				////////// not implemented yet ////////////
-                else if( ConstrainVout(tx.vout[2], 1, origTokensCCaddr, tokens) == false )  
+                else if( ConstrainVout(tx.vout[2], CCVOUT, origTokensCCaddr, tokens) == false )  
                     return eval->Invalid("vout2 doesnt match inputs fillex");
-                else if( ConstrainVout(tx.vout[1], 0, 0, 0) == false )
+                else if( ConstrainVout(tx.vout[1], NORMALVOUT, 0, 0) == false )
                     return eval->Invalid("vout1 is CC for fillex");
                 fprintf(stderr,"assets vout0 %lld, tokens %lld, vout2 %lld -> orig, vout1 %lld, total %lld\n", (long long)tx.vout[0].nValue, (long long)tokens,(long long)tx.vout[2].nValue,(long long)tx.vout[1].nValue,(long long)orig_units);
                 if( ValidateSwapRemainder(remaining_units, tx.vout[0].nValue, tokens, tx.vout[1].nValue, tx.vout[2].nValue, orig_units) == false )
                 //    return eval->Invalid("mismatched remainder for fillex");
-                else if( ConstrainVout(tx.vout[1], 1, 0, 0) == false )
+                else if( ConstrainVout(tx.vout[1], CCVOUT, 0, 0) == false )
 				////////// not implemented yet ////////////
                     return eval->Invalid("normal vout1 for fillex");
                 else if( remaining_units != 0 ) 
                 {
-                    if( ConstrainVout(tx.vout[0], 1, (char *)cpAssets->unspendableCCaddr, 0) == false )  // TODO: unsure about this, but this is not impl yet anyway
+                    if( ConstrainVout(tx.vout[0], CCVOUT, (char *)cpAssets->unspendableCCaddr, 0) == false )  // TODO: unsure about this, but this is not impl yet anyway
                         return eval->Invalid("mismatched vout0 AssetsCCaddr for fillex");
                 }
                 */

--- a/src/tui/tui_assets_orders.py
+++ b/src/tui/tui_assets_orders.py
@@ -117,7 +117,7 @@ def run_tokens_create(rpc):
             print("starting MofN tests for nftf7id1...")
             run_MofN_transfers(rpc1, rpc2, rpc3, nftf7id1, 1)
 
-    print("assets tests finished okay")
+    print("token/assets tests finished okay")
     time.sleep(3)
     exit
 
@@ -521,6 +521,15 @@ def run_assets_orders(rpc1, rpc2, v, tokenid, total, units, isnft):
         cancelid = call_token_rpc_send_tx(rpc1, "token"+v+"cancelbid", 'bid is empty', tokenid, fillbidid2)
         print("creating token"+v+"cancelbid tx #3...")
         cancelid = call_token_rpc_send_tx(rpc1, "token"+v+"cancelbid", 'bid is empty', tokenid, fillbidid3)
+
+    # create tokenbid to test dust
+    print("creating token"+v+"bid tx #4...")
+    bidid4 = call_token_rpc_send_tx(rpc1, "token"+v+"bid", '', str(1), tokenid, str(0.0000_01))
+    
+    # fill bid to self with dust
+    print("creating token"+v+"fillbid tx #4 (to create dust)...")
+    fillbidid4 = call_token_rpc_send_tx(rpc1, "token"+v+"fillbid", '', tokenid, bidid4, str(1), str(0.0000_005))
+
 
     # check balance after 
     retries = 24


### PR DESCRIPTION
mytokenorders uses a marker on mypk (instead global address), mypk marker conditional creation fixed
fixes for dust on normals in consensus 
more assets rules added for vout[0] 
not inited CCchange fixed in CreateSell rpc
vin_assetoshis in if() fixed in cancelbid validation
