### PR TITLE
Support for CLTV txns in wallet, NSPV fixes and improvement

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -231,6 +231,7 @@ public:
     bool operator()(const CPubKey& key) const { return addr->Set(key); }
     bool operator()(const CScriptID& id) const { return addr->Set(id); }
     bool operator()(const CCryptoConditionID& id) const { return addr->Set(id); }
+    bool operator()(const CCLTVID& id) const { return addr->Set(id); }
     bool operator()(const CNoDestination& no) const { return false; }
 };
 
@@ -258,6 +259,15 @@ bool CBitcoinAddress::Set(const CScriptID& id)
 bool CBitcoinAddress::Set(const CCryptoConditionID& id)
 {
     SetData(Params().Base58Prefix(CChainParams::CRYPTOCONDITION_ADDRESS), &id, 20);
+    return true;
+}
+
+bool CBitcoinAddress::Set(const CCLTVID& id)
+{
+    if (id.which() == TX_PUBKEY)
+        Set(id.GetPubKey());
+    else
+        Set(id.GetKeyID());
     return true;
 }
 
@@ -372,6 +382,15 @@ bool CCustomBitcoinAddress::Set(const CCryptoConditionID& id)
 {
     SetData(base58Prefixes[0], &id, 20);  // dimxy: CCryptoConditionID is actually CKeyID so we use base58Prefixes[0] as only two prefixes are supported in CCustomBitcoinAddress. 
                                           // TODO: check how it would work in gateways and importgateways 
+    return true;
+}
+
+bool CCustomBitcoinAddress::Set(const CCLTVID& id)
+{
+    if (id.which() == TX_PUBKEY)
+        Set(id.GetPubKey());
+    else
+        Set(id.GetKeyID());
     return true;
 }
 

--- a/src/base58.h
+++ b/src/base58.h
@@ -134,6 +134,7 @@ public:
     virtual bool Set(const CPubKey &key);
     virtual bool Set(const CScriptID &id);
     virtual bool Set(const CCryptoConditionID &id);
+    virtual bool Set(const CCLTVID& id);
     bool Set(const CTxDestination &dest);
     bool IsValid() const;
     bool IsValid(const CChainParams &params) const;
@@ -160,6 +161,7 @@ public:
     bool Set(const CScriptID &id);
     bool Set(const CTxDestination &dest);
     bool Set(const CCryptoConditionID &id);
+    bool Set(const CCLTVID& id);
     bool IsValid() const;
 
     CCustomBitcoinAddress() {}

--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -416,12 +416,6 @@ int32_t myIsutxo_spent(uint256 &spenttxid,uint256 txid,int32_t vout);
 int32_t myGet_mempool_txs(std::vector<CTransaction> &txs,uint8_t evalcode,uint8_t funcid);
 /// \endcond
 
-/// \cond INTERNAL
-#define IGUANA_READ 0
-#define IGUANA_WRITE 1
-int32_t iguana_rwnum(int32_t rwflag,uint8_t *serialized,int32_t len,void *endianedp);
-int32_t iguana_rwbignum(int32_t rwflag,uint8_t *serialized,int32_t len,uint8_t *endianedp);
-/// \endcond
 
 CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys);
 

--- a/src/cc/CCtx.cpp
+++ b/src/cc/CCtx.cpp
@@ -707,6 +707,8 @@ UniValue AddSignatureCCTxV2(vuint8_t & vtx, const UniValue &jsonParams)
 // set cc or normal unspents from mempool
 static void AddCCunspentsInMempool(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs, char *destaddr, bool isCC)
 {
+    if (!destaddr) return;
+    
     uint160 hashBytes;
     std::string addrstr(destaddr);
     CBitcoinAddress address(addrstr);
@@ -722,44 +724,6 @@ static void AddCCunspentsInMempool(std::vector<std::pair<CAddressUnspentKey, CAd
     std::vector< std::pair<uint160, int> > addresses;
     addresses.push_back(std::make_pair(hashBytes, type));
     mempool.getAddressIndex(addresses, memOutputs);
-   
-    //std::cerr << __func__ << " total memOutputs.size=" << memOutputs.size() << " hashBytes=" << hashBytes.GetHex() << " addrstr=" << addrstr << std::endl;
-
-    // non indexed impl:
-    /*
-    for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)  {
-        const CTransaction& memtx = mi->GetTx();
-        for (int32_t i = 0; i < memtx.vout.size(); i++)
-        {
-            uint256 dummytxid;
-            int32_t dummyvout;
-            if (!myIsutxo_spentinmempool(dummytxid, dummyvout, memtx.GetHash(), i))
-            {
-                if (isCC && memtx.vout[i].scriptPubKey.IsPayToCryptoCondition() || !isCC && !memtx.vout[i].scriptPubKey.IsPayToCryptoCondition())
-                {
-                    char voutaddr[64];
-                    Getscriptaddress(voutaddr, memtx.vout[i].scriptPubKey);
-                    if (strcmp(voutaddr, destaddr) == 0)
-                    {
-                        // create unspent output key value pair
-                        CAddressUnspentKey key;
-                        CAddressUnspentValue value;
-
-                        key.type = type;
-                        key.hashBytes = hashBytes;
-                        key.txhash = memtx.GetHash();
-                        key.index = i;
-
-                        value.satoshis = memtx.vout[i].nValue;
-                        value.blockHeight = 0;
-                        value.script = memtx.vout[i].scriptPubKey;
-                        unspentOutputs.push_back(std::make_pair(key, value));
-                    }
-                }
-            }
-        }
-    }
-    */
     
     // impl using mempool address and spent indexes
     for (std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> >::iterator mo = memOutputs.begin(); mo != memOutputs.end(); mo ++)
@@ -799,12 +763,9 @@ void SetCCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValu
         NSPV_CCunspents(unspentOutputs,coinaddr,ccflag);
         return;
     }
-    n = (int32_t)strlen(coinaddr);
-    addrstr.resize(n+1);
-    ptr = (char *)addrstr.data();
-    for (i=0; i<=n; i++)
-        ptr[i] = coinaddr[i];
-    CBitcoinAddress address(addrstr);
+    if (!coinaddr) return;
+
+    CBitcoinAddress address(coinaddr);
     if ( address.GetIndexKey(hashBytes, type, ccflag) == 0 )
         return;
     addresses.push_back(std::make_pair(hashBytes,type));
@@ -821,18 +782,6 @@ void SetCCunspentsWithMempool(std::vector<std::pair<CAddressUnspentKey, CAddress
     SetCCunspents(unspentOutputs, coinaddr, ccflag);
 
     // remove utxos spent in mempool
-    /* decided not to do this as the caller still needs to check is not spent in mempool
-    for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::iterator it = unspentOutputs.begin(); it != unspentOutputs.end(); )
-    {
-        uint256 dummytxid;
-        int32_t dummyvout;
-        if (myIsutxo_spentinmempool(dummytxid, dummyvout, it->first.txhash, it->first.index)) {
-            //std::cerr << __func__ << " erasing spent in mempool txid=" << it->first.txhash.GetHex() << " index=" << it->first.index << " spenttxid=" << dummytxid.GetHex() << std::endl;
-            it = unspentOutputs.erase(it);
-        }
-        else
-            it++;
-    } */
     AddCCunspentsInMempool(unspentOutputs, coinaddr, ccflag);
 }
 

--- a/src/cc/CCutils.cpp
+++ b/src/cc/CCutils.cpp
@@ -877,8 +877,9 @@ CAmount TotalPubkeyNormalInputs(Eval *eval, const CTransaction &tx, const CPubKe
             typedef std::vector<unsigned char> valtype;
             std::vector<valtype> vSolutions;
             txnouttype whichType;
+            bool iscltv;
 
-            if (Solver(vintx.vout[vin.prevout.n].scriptPubKey, whichType, vSolutions)) {
+            if (SolverCLTV(vintx.vout[vin.prevout.n].scriptPubKey, whichType, vSolutions, iscltv)) {
                 switch (whichType) {
                 case TX_PUBKEY:
                     if (pubkey == CPubKey(vSolutions[0]))   // is my input?

--- a/src/cc/includes/cJSON.h
+++ b/src/cc/includes/cJSON.h
@@ -46,7 +46,7 @@
 #include <float.h>
 #include <memory.h>
 
-#include "../crypto777/OS_portable.h"
+//#include "../crypto777/OS_portable.h"
 
 #define SATOSHIDEN ((uint64_t)100000000L)
 #define dstr(x) ((double)(x) / SATOSHIDEN)

--- a/src/cc/includes/curve25519.h
+++ b/src/cc/includes/curve25519.h
@@ -55,8 +55,8 @@ void vcalc_sha256(char hashstr[(256 >> 3) * 2 + 1],uint8_t hash[256 >> 3],uint8_
 void vcalc_sha256cat(uint8_t hash[256 >> 3],uint8_t *src,int32_t len,uint8_t *src2,int32_t len2);
 void vupdate_sha256(uint8_t hash[256 >> 3],struct sha256_vstate *state,uint8_t *src,int32_t len);
 bits256 curve25519_shared(bits256 privkey,bits256 otherpub);
-int32_t iguana_rwnum(int32_t rwflag,uint8_t *serialized,int32_t len,void *endianedp);
-int32_t iguana_rwbignum(int32_t rwflag,uint8_t *serialized,int32_t len,uint8_t *endianedp);
+//int32_t iguana_rwnum(int32_t rwflag,uint8_t *serialized,int32_t len,void *endianedp);
+//int32_t iguana_rwbignum(int32_t rwflag,uint8_t *serialized,int32_t len,uint8_t *endianedp);
 
 uint32_t calc_crc32(uint32_t crc,const void *buf,size_t size);
 uint64_t conv_NXTpassword(unsigned char *mysecret,unsigned char *mypublic,uint8_t *pass,int32_t passlen);

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -56,6 +56,14 @@ public:
         return EncodeBase58Check(data);
     }
 
+    std::string operator()(const CCLTVID& id) const
+    {
+        if (id.which() == TX_PUBKEY)
+            return operator()(id.GetPubKey());
+        else 
+            return operator()(id.GetKeyID());
+    }
+
     std::string operator()(const CNoDestination& no) const { return {}; }
 };
 

--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -735,7 +735,15 @@ int32_t komodo_opreturnscript(uint8_t *script,uint8_t type,uint8_t *opret,int32_
 #define CRYPTO777_KMDADDR "RXL3YXG2ceaB6C5hfJcN4fvmLH2C34knhA"
 extern int32_t KOMODO_PAX;
 int32_t komodo_is_issuer();
+
+// script tools analogue
+#define IGUANA_READ 0
+#define IGUANA_WRITE 1
 int32_t iguana_rwnum(int32_t rwflag,uint8_t *serialized,int32_t len,void *endianedp);
+int32_t iguana_rwbignum(int32_t rwflag,uint8_t *serialized,int32_t len,uint8_t *endianedp);
+int32_t iguana_rwvarint(int32_t rwflag, uint8_t* serialized, uint64_t* varint64p);
+int32_t iguana_rwbuf(int32_t rwflag,uint8_t *serialized,int32_t len,uint8_t *buf);
+
 int32_t pax_fiatstatus(uint64_t *available,uint64_t *deposited,uint64_t *issued,uint64_t *withdrawn,uint64_t *approved,uint64_t *redeemed,char *base);
 
 int32_t komodo_pending_withdraws(char *opretstr);

--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -759,4 +759,6 @@ int32_t komodo_kvsigverify(uint8_t *buf,int32_t len,uint256 _pubkey,uint256 sig)
 uint64_t komodo_interestnew(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uint32_t tiptime);
 uint64_t _komodo_interestnew(int32_t txheight,uint64_t nValue,uint32_t nLockTime,uint32_t tiptime);
 
+uint32_t komodo_next_tx_locktime();
+
 #endif

--- a/src/komodo_nSPV.h
+++ b/src/komodo_nSPV.h
@@ -584,6 +584,8 @@ uint256 NSPV_opretextract(int32_t *heightp,uint256 *blockhashp,char *symbol,std:
 int32_t NSPV_notarizationextract(int32_t verifyntz,int32_t *ntzheightp,uint256 *blockhashp,uint256 *desttxidp,CTransaction tx)
 {
     int32_t numsigs=0; uint8_t elected[64][33]; char *symbol; std::vector<uint8_t> opret; uint32_t nTime;
+    AssertLockHeld(cs_main);
+
     if ( tx.vout.size() >= 2 )
     {
         symbol = (ASSETCHAINS_SYMBOL[0] == 0) ? (char *)"KMD" : ASSETCHAINS_SYMBOL;
@@ -596,16 +598,19 @@ int32_t NSPV_notarizationextract(int32_t verifyntz,int32_t *ntzheightp,uint256 *
             komodo_notaries(elected,*ntzheightp,nTime);
             if ( verifyntz != 0 && (numsigs= NSPV_fastnotariescount(tx,elected,nTime)) < 12 )
             {
-                fprintf(stderr,"numsigs.%d error\n",numsigs);
+                LogPrintf("%s error numsigs.%d less than 12\n", __func__, numsigs);
                 return(-3);
             } 
             return(0);
         }
         else
         {
-            fprintf(stderr,"opretsize.%d error\n",(int32_t)opret.size());
+            LogPrintf("%s opretsize.%d error\n", __func__, (int32_t)opret.size());
             return(-2);
         }
-    } else return(-1);
+    } else {
+        LogPrintf("%s tx.vout.size().%d error\n", __func__, (int32_t)tx.vout.size());
+        return(-1);
+    }
 }
 #endif // KOMODO_NSPV_H

--- a/src/komodo_nSPV_defs.h
+++ b/src/komodo_nSPV_defs.h
@@ -25,6 +25,7 @@
 #define NSPV_MAXVINS 64
 #define NSPV_AUTOLOGOUT 777
 #define NSPV_BRANCHID 0x76b809bb
+#define NSPV_MAXJSONREQUESTSIZE 65536
 
 // nSPV defines and struct definitions with serialization and purge functions
 

--- a/src/komodo_nSPV_defs.h
+++ b/src/komodo_nSPV_defs.h
@@ -95,6 +95,7 @@ struct NSPV_utxoresp
     uint256 txid;
     int64_t satoshis,extradata;
     int32_t vout,height;
+    uint8_t *script; uint64_t script_size;
 };
 
 struct NSPV_utxosresp
@@ -103,14 +104,14 @@ struct NSPV_utxosresp
     char coinaddr[64];
     int64_t total,interest;
     int32_t nodeheight,skipcount,maxrecords;
-    uint16_t numutxos,CCflag;
+    uint16_t numutxos, CCflag;
 };
 
 struct NSPV_txidresp
 {
     uint256 txid;
     int64_t satoshis;
-    int32_t vout,height;
+    int32_t vout, height;
 };
 
 struct NSPV_txidsresp

--- a/src/komodo_nSPV_defs.h
+++ b/src/komodo_nSPV_defs.h
@@ -19,13 +19,14 @@
 
 #include <stdlib.h>
 
-#define NSPV_PROTOCOL_VERSION 0x00000004
+#define NSPV_PROTOCOL_VERSION 0x00000005
 #define NSPV_POLLITERS 200
 #define NSPV_POLLMICROS 50000
 #define NSPV_MAXVINS 64
 #define NSPV_AUTOLOGOUT 777
 #define NSPV_BRANCHID 0x76b809bb
 #define NSPV_MAXJSONREQUESTSIZE 65536
+#define NSPV_REQUESTIDSIZE 4
 
 // nSPV defines and struct definitions with serialization and purge functions
 
@@ -57,8 +58,20 @@
 #define NSPV_CC_TXIDS 16
 #define NSPV_REMOTERPC 0x14
 #define NSPV_REMOTERPCRESP 0x15
+#define NSPV_ERRORRESP 0xff
+
+#define NSPV_ERROR_INVALID_REQUEST_TYPE     (-10)
+#define NSPV_ERROR_INVALID_REQUEST_DATA     (-11)
+#define NSPV_ERROR_GETINFO_FIRST            (-12)
+#define NSPV_ERROR_INVALID_VERSION          (-13)
+#define NSPV_ERROR_READ_DATA                (-14)
+#define NSPV_ERROR_INVALID_RESPONSE         (-15)
+#define NSPV_ERROR_BROADCAST                (-16)
+#define NSPV_ERROR_REMOTE_RPC               (-17)
 
 #define NSPV_MAXREQSPERSEC 15
+
+#define NSPV_MAX_VARINT_SIZE 9
 
 int32_t NSPV_gettransaction(int32_t skipvalidation,int32_t vout,uint256 txid,int32_t height,CTransaction &tx,uint256 &hashblock,int32_t &txheight,int32_t &currentheight,int64_t extradata,uint32_t tiptime,int64_t &rewardsum);
 UniValue NSPV_spend(char *srcaddr,char *destaddr,int64_t satoshis);
@@ -199,5 +212,7 @@ extern struct NSPV_inforesp NSPV_inforesult;
 void NSPV_CCunspents(std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs, char* coinaddr, bool ccflag);
 void NSPV_CCindexOutputs(std::vector<std::pair<CAddressIndexKey, CAmount>>& indexOutputs, char* coinaddr, bool ccflag);
 void NSPV_CCtxids(std::vector<uint256>& txids, char* coinaddr, bool ccflag, uint8_t evalcode, uint256 filtertxid, uint8_t func);
+
+extern std::map<int32_t, std::string> nspvErrors;
 
 #endif // KOMODO_NSPV_DEFSH

--- a/src/komodo_nSPV_fullnode.h
+++ b/src/komodo_nSPV_fullnode.h
@@ -1001,14 +1001,14 @@ void komodo_nSPVreq(CNode* pfrom, std::vector<uint8_t> request) // received a re
 
             //fprintf(stderr,"check info %u vs %u, ind.%d\n", timestamp, pfrom->nspvdata[ind].prevtime, ind);
             if (requestDataLen != sizeof(version) + sizeof(reqheight)) {
-                LogPrint("nspv-details", "NSPV_INFO invalid request from node=%d\n", pfrom->id);
+                LogPrint("nspv", "NSPV_INFO invalid request from node=%d\n", pfrom->id);
                 NSPV_senderror(pfrom, requestId, NSPV_ERROR_INVALID_REQUEST_DATA);
                 return;
             }
             int32_t offset = 0;
             offset += iguana_rwnum(IGUANA_READ, &requestData[offset], sizeof(version), &version);
             if (version != NSPV_PROTOCOL_VERSION)  {
-                LogPrint("nspv", "nspv version %d not supported from node=%d\n", version, pfrom->id);
+                LogPrint("nspv", "NSPV_INFO nspv version %d not supported from node=%d\n", version, pfrom->id);
                 NSPV_senderror(pfrom, requestId, NSPV_ERROR_INVALID_VERSION);
                 return;
             }
@@ -1027,7 +1027,7 @@ void komodo_nSPVreq(CNode* pfrom, std::vector<uint8_t> request) // received a re
                     pfrom->PushMessage("nSPV", response);
                     pfrom->nspvdata[idata].prevtime = timestamp;
                     pfrom->nspvdata[idata].nreqs++;
-                    LogPrint("nspv-details", "NSPV_INFO response: version %d to node=%d\n", I.version, pfrom->id);
+                    LogPrint("nspv-details", "NSPV_INFO sent response: version %d to node=%d\n", I.version, pfrom->id);
                     pfrom->fNspvConnected = true; // allow to do nspv requests
                 } else {
                     LogPrint("nspv", "NSPV_rwinforesp incorrect response len.%d\n", respLen);

--- a/src/komodo_nSPV_fullnode.h
+++ b/src/komodo_nSPV_fullnode.h
@@ -1001,7 +1001,7 @@ void komodo_nSPVreq(CNode* pfrom, std::vector<uint8_t> request) // received a re
 
             //fprintf(stderr,"check info %u vs %u, ind.%d\n", timestamp, pfrom->nspvdata[ind].prevtime, ind);
             if (requestDataLen != sizeof(version) + sizeof(reqheight)) {
-                LogPrint("nspv", "NSPV_INFO invalid request from node=%d\n", pfrom->id);
+                LogPrint("nspv", "NSPV_INFO invalid request size %d from node=%d\n", requestDataLen, pfrom->id);
                 NSPV_senderror(pfrom, requestId, NSPV_ERROR_INVALID_REQUEST_DATA);
                 return;
             }

--- a/src/komodo_nSPV_fullnode.h
+++ b/src/komodo_nSPV_fullnode.h
@@ -53,7 +53,7 @@ static std::map<std::string,bool> nspv_remote_commands =  {
     { "tokenask", false }, { "tokenbid", false }, { "tokenfillask", false }, { "tokenfillbid", false }, { "tokencancelask", false }, { "tokencancelbid", false }, 
     { "tokenorders", false }, { "mytokenorders", false }, { "tokentransfer", false },{ "tokencreate", false },
     { "tokenv2ask", true }, { "tokenv2bid", true }, { "tokenv2fillask", true }, { "tokenv2fillbid", true }, { "tokenv2cancelask", true }, { "tokenv2cancelbid", true }, 
-    { "tokenv2orders", true }, { "mytokenv2orders", true }, { "tokenv2transfer", true },{ "tokenv2create", true }, { "tokenv2address", true },
+    { "tokenv2orders", true }, { "mytokenv2orders", true }, { "tokenv2transfer", false }, { "tokenv2create", false }, { "tokenv2address", true },
     // nspv helpers
     { "createtxwithnormalinputs", true }, { "tokenv2addccinputs", true }, { "tokenv2infotokel", true }, { "gettransactionsmany", true },
 };

--- a/src/komodo_nSPV_superlite.h
+++ b/src/komodo_nSPV_superlite.h
@@ -404,6 +404,8 @@ UniValue NSPV_utxoresp_json(struct NSPV_utxoresp *utxos,int32_t numutxos)
         item.push_back(Pair("value",(double)utxos[i].satoshis/COIN));
         if ( ASSETCHAINS_SYMBOL[0] == 0 )
             item.push_back(Pair("interest",(double)utxos[i].extradata/COIN));
+        if (utxos[i].script)
+            item.push_back(Pair("script", HexStr(utxos[i].script, utxos[i].script+utxos[i].script_size)));
         array.push_back(item);
     }
     return(array);
@@ -435,9 +437,10 @@ UniValue NSPV_txidresp_json(struct NSPV_txidresp *utxos,int32_t numutxos)
         item.push_back(Pair("height",(int64_t)utxos[i].height));
         item.push_back(Pair("txid",utxos[i].txid.GetHex()));
         item.push_back(Pair("value",(double)utxos[i].satoshis/COIN));
-        if ( utxos[i].satoshis > 0 )
-            item.push_back(Pair("vout",(int64_t)utxos[i].vout));
-        else item.push_back(Pair("vin",(int64_t)utxos[i].vout));
+        if (utxos[i].satoshis > 0)
+            item.push_back(Pair("vout", (int64_t)utxos[i].vout));
+        else
+            item.push_back(Pair("vin", (int64_t)utxos[i].vout));
         array.push_back(item);
     }
     return(array);

--- a/src/komodo_nSPV_wallet.h
+++ b/src/komodo_nSPV_wallet.h
@@ -18,6 +18,10 @@
 #define KOMODO_NSPVWALLET_H
 
 #include "rpc/server.h"
+#include "komodo_nSPV_defs.h"
+#include "komodo_nSPV.h"
+#include "komodo_nSPV_superlite.h"
+
 
 // nSPV wallet uses superlite functions (and some komodod built in functions) to implement nSPV_spend
 //extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2644,3 +2644,12 @@ bool komodo_txnotarizedconfirmed(uint256 txid, int32_t minconfirms)
         return (true);
     return (false);
 }
+
+uint32_t komodo_next_tx_locktime()
+{
+    AssertLockHeld(cs_main);
+    if (!komodo_hardfork_active((uint32_t)chainActive.LastTip()->nTime))
+        return (uint32_t)chainActive.LastTip()->nTime + 1; // set to a time close to now
+    else
+        return (uint32_t)chainActive.Tip()->GetMedianTimePast();
+}

--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -2645,6 +2645,7 @@ bool komodo_txnotarizedconfirmed(uint256 txid, int32_t minconfirms)
     return (false);
 }
 
+// creates a nLockTime value for a new tx, with Dec 2019 hardfork check
 uint32_t komodo_next_tx_locktime()
 {
     AssertLockHeld(cs_main);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1044,8 +1044,11 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
         const CScript& prevScript = prev.scriptPubKey;
         //printf("Previous script: %s\n", prevScript.ToString().c_str());
 
-        if (!Solver(prevScript, whichType, vSolutions))
+        bool iscltv;
+        // allow CLTV inputs:
+        if (!SolverCLTV(prevScript, whichType, vSolutions, iscltv)) 
             return false;
+            
         int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
         if (nArgsExpected < 0)
             return false;

--- a/src/main.h
+++ b/src/main.h
@@ -121,14 +121,14 @@ static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 
-/** Default NSPV support enabled */
+/** Default NSPV support enabled for Tokel */
 static const bool DEFAULT_NSPV_PROCESSING = true;
 
-//static const bool DEFAULT_ADDRESSINDEX = false;
-//static const bool DEFAULT_SPENTINDEX = false;
 #define DEFAULT_ADDRESSINDEX (GetArg("-ac_cc",0) != 0 || GetArg("-ac_ccactivate",0) != 0)
 #define DEFAULT_SPENTINDEX (GetArg("-ac_cc",0) != 0 || GetArg("-ac_ccactivate",0) != 0)
-#define DEFAULT_UNSPENTCCINDEX true
+
+/** Default unspent cc enabled for Tokel */
+static const bool DEFAULT_UNSPENTCCINDEX = true;
 
 static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const unsigned int DEFAULT_DB_MAX_OPEN_FILES = 1000;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2130,6 +2130,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fInbound = fInboundIn;
     fNetworkNode = false;
     fSuccessfullyConnected = false;
+    fNspvConnected = false;
     fDisconnect = false;
     nRefCount = 0;
     nSendSize = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -308,6 +308,7 @@ public:
     bool fInbound;
     bool fNetworkNode;
     bool fSuccessfullyConnected;
+    bool fNspvConnected;
     bool fDisconnect;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -390,6 +390,13 @@ public:
         return obj;
     }
 
+    UniValue operator()(const CCLTVID &cltvID) const {
+        if (cltvID.which() == TX_PUBKEY)
+            return this->operator()(cltvID.GetPubKey());
+        else 
+            return this->operator()(cltvID.GetKeyID());
+    }    
+
     UniValue operator()(const CCryptoConditionID &ccID) const { return UniValue(UniValue::VOBJ); }  // cryptoconditions are not recognised in the wallet yet
 };
 #endif
@@ -858,7 +865,7 @@ bool getAddressFromIndex(const int &type, const uint160 &hash, std::string &addr
     } else if (type == 1) {
         address = CBitcoinAddress(CKeyID(hash)).ToString();
     } else if (type == 3) {
-        address = CBitcoinAddress(CKeyID(hash)).ToString();
+        address = CBitcoinAddress(CCryptoConditionID(hash)).ToString();
     } else {
         return false;
     }

--- a/src/rpc/tokensrpc.cpp
+++ b/src/rpc/tokensrpc.cpp
@@ -347,6 +347,8 @@ static UniValue tokencreate(const UniValue& params, const vuint8_t &vtokenData, 
     UniValue result(UniValue::VOBJ);
     std::string name, description, hextx; 
     CAmount supply; // changed from uin64_t to int64_t for this 'if ( supply <= 0 )' to work as expected
+    const CPubKey nullpk;
+    const CAmount txfee = 0;
 
     CCerror.clear();
 
@@ -373,9 +375,11 @@ static UniValue tokencreate(const UniValue& params, const vuint8_t &vtokenData, 
             return MakeResultError("Token description must be <= " + std::to_string(TOKENS_MAX_DESC_LENGTH));  // allowed > MAX_SCRIPT_ELEMENT_SIZE
     }
 
-    hextx = CreateTokenLocal<V>(0, supply, name, description, vtokenData);
+    //hextx = CreateTokenLocal<V>(0, supply, name, description, vtokenData);
+    UniValue rcreate = CreateTokenExt<V>(remotepk.IsValid() ? remotepk : nullpk, txfee, supply, name, description, vtokenData, 0, false); 
     RETURN_IF_ERROR(CCerror);
 
+    hextx = ResultGetTx(rcreate);
     if( hextx.size() > 0 )     
         return MakeResultSuccess(hextx);
     else

--- a/src/rpc/tokensrpc.cpp
+++ b/src/rpc/tokensrpc.cpp
@@ -345,7 +345,7 @@ template <class V>
 static UniValue tokencreate(const UniValue& params, const vuint8_t &vtokenData, bool fHelp, const CPubKey& remotepk)
 {
     UniValue result(UniValue::VOBJ);
-    std::string name, description, hextx; 
+    std::string name, description; 
     CAmount supply; // changed from uin64_t to int64_t for this 'if ( supply <= 0 )' to work as expected
     const CPubKey nullpk;
     const CAmount txfee = 0;
@@ -379,11 +379,15 @@ static UniValue tokencreate(const UniValue& params, const vuint8_t &vtokenData, 
     UniValue rcreate = CreateTokenExt<V>(remotepk.IsValid() ? remotepk : nullpk, txfee, supply, name, description, vtokenData, 0, false); 
     RETURN_IF_ERROR(CCerror);
 
-    hextx = ResultGetTx(rcreate);
-    if( hextx.size() > 0 )     
-        return MakeResultSuccess(hextx);
-    else
-        return MakeResultError("could not create token");
+    if (remotepk.IsValid())
+        return rcreate;
+    else {
+        std::string  hextx = ResultGetTx(rcreate);
+        if( hextx.size() > 0 )     
+            return MakeResultSuccess(hextx);
+        else
+            return MakeResultError("could not create token");
+    }
 }
 
 UniValue tokencreate(const UniValue& params, bool fHelp, const CPubKey& remotepk)

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -347,25 +347,10 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
     ret.clear();
     
     vector<valtype> vSolutions;
+    bool iscltv;
     
-    if (!Solver(scriptPubKey, whichTypeRet, vSolutions))
-    {
-        // if this is a CLTV script, solve for the destination after CLTV
-        if (scriptPubKey.IsCheckLockTimeVerify())
-        {
-            uint8_t pushOp = scriptPubKey[0];
-            uint32_t scriptStart = pushOp + 3;
-            
-            // check post CLTV script
-            CScript postfix = CScript(scriptPubKey.size() > scriptStart ? scriptPubKey.begin() + scriptStart : scriptPubKey.end(), scriptPubKey.end());
-            
-            // check again with only postfix subscript
-            if (!Solver(postfix, whichTypeRet, vSolutions))
-                return false;
-        }
-        else
-            return false;
-    }
+    if (!SolverCLTV(scriptPubKey, whichTypeRet, vSolutions, iscltv))
+        return false;
     
     CKeyID keyID;
     switch (whichTypeRet)

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -85,10 +85,63 @@ enum txnouttype
     TX_PUBKEY,
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
-    TX_MULTISIG,
     TX_CRYPTOCONDITION,
+    TX_CLTV, 
+    // ^^ enum order matches types' order in CTxDestination
+    TX_MULTISIG,
     TX_NULL_DATA,
 };
+
+class CCLTVID
+{
+private:
+    int64_t unlockTime;
+    txnouttype whichType;
+    union {
+        CKeyID keyid;
+        CPubKey pubkey;
+    };
+    bool unlocked;
+public:
+    CCLTVID(const CKeyID &id, int64_t ut) : keyid(id), unlockTime(ut), whichType(TX_PUBKEYHASH), unlocked(false) {}
+    CCLTVID(const CPubKey &pk, int64_t ut) : pubkey(pk), unlockTime(ut), whichType(TX_PUBKEY), unlocked(false) {}
+
+    txnouttype which() const { return whichType; }
+    int64_t GetUnlockTime() const { return unlockTime; }
+    CKeyID GetKeyID() const { return keyid; }
+    CPubKey GetPubKey() const { return pubkey; }
+    CKeyID GetID() const {
+        if (whichType == TX_PUBKEYHASH)
+            return keyid;
+        else 
+            return pubkey.GetID();
+    }
+    void SetUnlocked() { unlocked = true; }
+    bool IsUnlocked() const { return unlocked; }
+    friend bool operator==(const CCLTVID &a, const CCLTVID &b) { 
+        if (a.whichType == TX_PUBKEY && b.whichType == TX_PUBKEY)  
+            return a.pubkey == b.pubkey && a.unlocked == b.unlocked; 
+        else 
+            return a.GetID() == b.GetID() && a.unlocked == b.unlocked; 
+    }
+    friend bool operator<(const CCLTVID &a, const CCLTVID &b) { 
+        if (a.whichType == TX_PUBKEY && b.whichType == TX_PUBKEY)  {
+            if (a.pubkey < b.pubkey) 
+                return true;
+            else if (a.pubkey == b.pubkey) 
+                return a.unlocked < b.unlocked;
+            return false;
+        }
+        else {
+            if (a.GetID() < b.GetID())
+                return true;
+            else if (a.GetID() == b.GetID())
+                return a.unlocked < b.unlocked;
+            return false;
+        }
+    }
+};
+
 
 class CNoDestination {
 public:
@@ -101,15 +154,19 @@ public:
  *  * CNoDestination: no destination set
  *  * CKeyID: TX_PUBKEYHASH destination
  *  * CScriptID: TX_SCRIPTHASH destination
+ *  Komodo added:
+ *  * CCryptoConditionID: TX_CRYPTOCONDITION destination
+ *  * CCLTVID TX_CLTV destination
  *  A CTxDestination is the internal data type encoded in a bitcoin address
  */
-typedef boost::variant<CNoDestination, CPubKey, CKeyID, CScriptID, CCryptoConditionID> CTxDestination;
+typedef boost::variant<CNoDestination, CPubKey, CKeyID, CScriptID, CCryptoConditionID, CCLTVID> CTxDestination;
 
+// Verus-format for additional data added after cryptocondition as OP_DROP in the spk
 class COptCCParams
 {
     public:
         static const uint8_t VERSION_1 = 1;
-        static const uint8_t VERSION_2 = 2; // i needede to add version2 to allow adding pubkeys (as we violated the OptCCParams format by not adding pubkeys in MakeCCVout1,...)
+        static const uint8_t VERSION_2 = 2; // i needed to add version2 to allow adding pubkeys (as we violated the OptCCParams format by not adding pubkeys in MakeCCVout1,...)
         static bool isMyVersion(uint8_t version) { return version >= 1 && version <= 2; }
         uint8_t version;
         uint8_t evalCode;
@@ -176,6 +233,7 @@ bool IsValidDestination(const CTxDestination& dest);
 const char* GetTxnOutputType(txnouttype t);
 
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
+bool SolverCLTV(const CScript& _scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet, bool &isCltv);
 int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char> >& vSolutions);
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet, bool returnPubKey=false);

--- a/src/test-komodo/test_script_standard_tests.cpp
+++ b/src/test-komodo/test_script_standard_tests.cpp
@@ -38,6 +38,9 @@ namespace TestScriptStandartTests {
             case TX_CRYPTOCONDITION:
                 res = "TX_CRYPTOCONDITION";
                 break;
+            case TX_CLTV:
+                res = "TX_CLTV";
+                break;
             default:
                 res = "UNKNOWN";
             }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -866,10 +866,16 @@ UniValue listaddressgroupings(const UniValue& params, bool fHelp, const CPubKey&
             UniValue addressInfo(UniValue::VARR);
             addressInfo.push_back(EncodeDestination(address));
             if (address.which() == TX_CLTV)   {
-                if (boost::get<CCLTVID>(address).IsUnlocked())
+                const CCLTVID &cltv = boost::get<CCLTVID>(address);
+                if (cltv.IsUnlocked())
                     addressInfo.push_back("CLTV-spendable");
-                else
+                else {
                     addressInfo.push_back("CLTV-locked");
+                    if (cltv.GetUnlockTime() > LOCKTIME_THRESHOLD)
+                        addressInfo.push_back( strprintf("%lld (%s)", cltv.GetUnlockTime(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S UTC", cltv.GetUnlockTime())) );
+                    else 
+                        addressInfo.push_back( strprintf("%lld", cltv.GetUnlockTime()) );
+                }
             }
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
@@ -5507,9 +5513,9 @@ UniValue z_listoperationids(const UniValue& params, bool fHelp, const CPubKey& m
 }
 
 
-#include "script/sign.h"
-int32_t decode_hex(uint8_t *bytes,int32_t n,char *hex);
-extern std::string NOTARY_PUBKEY;
+//#include "script/sign.h"
+//int32_t decode_hex(uint8_t *bytes,int32_t n,char *hex);
+//extern std::string NOTARY_PUBKEY;
 
 int32_t komodo_notaryvin(CMutableTransaction &txNew,uint8_t *notarypub33, void *pTr)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -463,7 +463,7 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp, const CPubKey
     return ret;
 }
 
-static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew,uint8_t *opretbuf,int32_t opretlen,long int opretValue)
+static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew,uint8_t *opretbuf,int32_t opretlen,long int opretValue, int64_t unlockTime = 0LL)
 {
     CAmount curBalance = pwalletMain->GetBalance();
 
@@ -474,8 +474,15 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
     if (nValue > curBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
 
-    // Parse Zcash address
-    CScript scriptPubKey = GetScriptForDestination(address);
+    // make scriptPubKey for destination
+    CScriptExt scriptPubKey;
+    if (unlockTime == 0) 
+        scriptPubKey = GetScriptForDestination(address);
+    else  {
+        CKeyID keyid; 
+        if (CBitcoinAddress(address).GetKeyID(keyid))
+            scriptPubKey.TimeLockSpend(keyid, unlockTime);
+    }
     if (scriptPubKey.empty())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid destination");
 
@@ -511,17 +518,17 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
 
 UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
 {
-    uint8_t opretbuf[IGUANA_MAXSCRIPTSIZE],opretscript[IGUANA_MAXSCRIPTSIZE],*opret=0; char *oprethexstr; int32_t len,opretlen = 0;
+    uint8_t opretbuf[IGUANA_MAXSCRIPTSIZE],opretscript[IGUANA_MAXSCRIPTSIZE],*opret=0; char *oprethexstr; int32_t len, opretlen = 0;
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    if (fHelp || params.size() < 2 || params.size() > 6)
+    if (fHelp || params.size() < 2 || params.size() > 7)
         throw runtime_error(
-            "sendtoaddress \"" + strprintf("%s",komodo_chainname()) + "_address\" amount ( \"comment\" \"comment-to\" subtractfeefromamount )\n"
+            "sendtoaddress \"" + strprintf("%s",komodo_chainname()) + "_address\" amount ( \"comment\" \"comment-to\" subtractfeefromamount unlocktime )\n"
             "\nSend an amount to a given address. The amount is a real and is rounded to the nearest 0.00000001\n"
             + HelpRequiringPassphrase() +
             "\nArguments:\n"
-            "1. \"" + strprintf("%s",komodo_chainname()) + "_address\"  (string, required) The " + strprintf("%s",komodo_chainname()) + " address to send to.\n"
+            "1. \"" + strprintf("%s", komodo_chainname()) + "_address\"  (string, required) The " + strprintf("%s",komodo_chainname()) + " address to send to.\n"
             "2. \"amount\"      (numeric, required) The amount in " + strprintf("%s",komodo_chainname()) + " to send. eg 0.1\n"
             "3. \"comment\"     (string, optional) A comment used to store what the transaction is for. \n"
             "                             This is not part of the transaction, just kept in your wallet.\n"
@@ -529,13 +536,16 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
             "                             to which you're sending the transaction. This is not part of the \n"
             "                             transaction, just kept in your wallet.\n"
             "5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n"
-            "                             The recipient will receive less " + strprintf("%s",komodo_chainname()) + " than you enter in the amount field.\n6. oprethexstr"
+            "                             The recipient will receive less " + strprintf("%s",komodo_chainname()) + " than you enter in the amount field.\n"
+            "6. oprethexstr\n"
+            "7. unlocktime (numeric, optional) timestamp or blockheight when the sent funds will be unlocked by CLTV opcode\n"
             "\nResult:\n"
             "\"transactionid\"  (string) The transaction id.\n"
             "\nExamples:\n"
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1")
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"donation\" \"seans outpost\"")
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"\" \"\" true")
+            + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"donation\" \"seans outpost\" false \"\" 2595973")
             + HelpExampleRpc("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\", 0.1, \"donation\", \"seans outpost\"")
         );
 
@@ -568,20 +578,27 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
     bool fSubtractFeeFromAmount = false;
     if (params.size() > 4)
         fSubtractFeeFromAmount = params[4].get_bool();
-    if (params.size() > 5)
-    {
-        oprethexstr = (char *)params[5].get_str().c_str();
-        if ( (len= is_hexstr(oprethexstr,0)) > 1 && len <= sizeof(opretbuf)*2 )
-        {
+    if (params.size() > 5) {
+        oprethexstr = (char*)params[5].get_str().c_str();
+        if ((len = is_hexstr(oprethexstr, 0)) > 1 && len <= sizeof(opretbuf) * 2) {
             len >>= 1;
-            decode_hex(opretbuf,len,oprethexstr);
-            opretlen = komodo_opreturnscript(opretscript,0x00,opretbuf,len);
+            decode_hex(opretbuf, len, oprethexstr);
+            opretlen = komodo_opreturnscript(opretscript, 0x00, opretbuf, len);
             opret = opretscript;
-        } else opretlen = 0;
+        } else
+            opretlen = 0;
     }
+    int64_t unlockTime = 0LL;
+    if (params.size() > 6)  {
+        unlockTime = atoll(params[6].get_str().c_str());
+        if (unlockTime < 0LL)
+            throw JSONRPCError(RPC_TYPE_ERROR, "invalid unlock time");
+    }
+
+
     EnsureWalletIsUnlocked();
 
-    SendMoney(dest, nAmount, fSubtractFeeFromAmount, wtx,opret,opretlen,0);
+    SendMoney(dest, nAmount, fSubtractFeeFromAmount, wtx, opret, opretlen, 0, unlockTime);
 
     return wtx.GetHash().GetHex();
 }
@@ -839,14 +856,21 @@ UniValue listaddressgroupings(const UniValue& params, bool fHelp, const CPubKey&
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
+    int64_t txLockTime = komodo_next_tx_locktime();
     UniValue jsonGroupings(UniValue::VARR);
-    std::map<CTxDestination, CAmount> balances = pwalletMain->GetAddressBalances();
-    for (const std::set<CTxDestination>& grouping : pwalletMain->GetAddressGroupings()) {
+    std::map<CTxDestination, CAmount> balances = pwalletMain->GetAddressBalances(txLockTime);
+    for (const std::set<CTxDestination>& grouping : pwalletMain->GetAddressGroupings(txLockTime)) {
         UniValue jsonGrouping(UniValue::VARR);
         for (const CTxDestination& address : grouping)
         {
             UniValue addressInfo(UniValue::VARR);
             addressInfo.push_back(EncodeDestination(address));
+            if (address.which() == TX_CLTV)   {
+                if (boost::get<CCLTVID>(address).IsUnlocked())
+                    addressInfo.push_back("CLTV-spendable");
+                else
+                    addressInfo.push_back("CLTV-locked");
+            }
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
                 if (pwalletMain->mapAddressBook.find(address) != pwalletMain->mapAddressBook.end()) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -522,7 +522,7 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    if (fHelp || params.size() < 2 || params.size() > 7)
+    if (fHelp || params.size() < 2 || params.size() > 6)
         throw runtime_error(
             "sendtoaddress \"" + strprintf("%s",komodo_chainname()) + "_address\" amount ( \"comment\" \"comment-to\" subtractfeefromamount unlocktime )\n"
             "\nSend an amount to a given address. The amount is a real and is rounded to the nearest 0.00000001\n"
@@ -545,7 +545,7 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1")
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"donation\" \"seans outpost\"")
             + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"\" \"\" true")
-            + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"donation\" \"seans outpost\" false \"\" 2595973")
+// test cltv: + HelpExampleCli("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\" 0.1 \"donation\" \"seans outpost\" false \"\" 1634663625")
             + HelpExampleRpc("sendtoaddress", "\"RD6GgnrMpPaTSMn8vai6yiGA7mN4QGPV\", 0.1, \"donation\", \"seans outpost\"")
         );
 
@@ -588,17 +588,18 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp, const CPubKey& mypk)
         } else
             opretlen = 0;
     }
+
+    /* test cltv coins:
     int64_t unlockTime = 0LL;
     if (params.size() > 6)  {
         unlockTime = atoll(params[6].get_str().c_str());
         if (unlockTime < 0LL)
             throw JSONRPCError(RPC_TYPE_ERROR, "invalid unlock time");
-    }
-
+    } */
 
     EnsureWalletIsUnlocked();
 
-    SendMoney(dest, nAmount, fSubtractFeeFromAmount, wtx, opret, opretlen, 0, unlockTime);
+    SendMoney(dest, nAmount, fSubtractFeeFromAmount, wtx, opret, opretlen, 0, 0LL);
 
     return wtx.GetHash().GetHex();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -470,7 +470,7 @@ bool CWallet::LoadCScript(const CScript& redeemScript)
     {
         std::string strAddr = EncodeDestination(CScriptID(redeemScript));
         LogPrintf("%s: Warning: This wallet contains a redeemScript of size %i which exceeds maximum size %i thus can never be redeemed. Do not use address %s.\n",
-            __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr.c_str());
+            __func__, redeemScript.size(), MAX_SCRIPT_ELEMENT_SIZE, strAddr);
         return true;
     }
 
@@ -1795,7 +1795,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
                                 {
                                     fIsFromWhiteList = true;
                                     // std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " passed wallet filter! whitelistaddress." << EncodeDestination(dest) << std::endl;
-                                    LogPrintf("tx.%s passed wallet filter! whitelistaddress.%s\n", tx.GetHash().ToString().c_str(),EncodeDestination(dest).c_str());
+                                    LogPrintf("tx.%s passed wallet filter! whitelistaddress.%s\n", tx.GetHash().ToString(),EncodeDestination(dest));
                                     break;
                                 }
                             }
@@ -1804,7 +1804,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
                     if (!fIsFromWhiteList)
                     {
                         // std::cerr << __FUNCTION__ << " tx." << tx.GetHash().ToString() << " is NOT passed wallet filter!" << std::endl;
-                        LogPrintf("tx.%s is NOT passed wallet filter!\n", tx.GetHash().ToString().c_str());
+                        LogPrintf("tx.%s is NOT passed wallet filter!\n", tx.GetHash().ToString());
                         return false;
                     }
                 }
@@ -2211,7 +2211,7 @@ isminetype CWallet::IsMine(const CTransaction& tx, uint32_t voutNum)
 {
     vector<valtype> vSolutions;
     txnouttype whichType;
-    CScriptExt scriptPubKey = CScriptExt(tx.vout[voutNum].scriptPubKey);
+    const CScriptExt scriptPubKey = CScriptExt(tx.vout[voutNum].scriptPubKey);
     bool iscltv;
 
     if (!SolverCLTV(scriptPubKey, whichType, vSolutions, iscltv)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -993,7 +993,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeCoinBase=true) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeCoinBase=true, int64_t txLockTime = 0L) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
@@ -1518,28 +1518,17 @@ public:
     SpendingKeyAddResult operator()(const libzcash::InvalidEncoding& no) const;    
 };
 
-// helper to check if locktime from OP_CLTV opcode not more than tx lock time
-inline bool CheckLockTime(int64_t nLockTime, int64_t txLockTime)
+/*inline void TokelRemoveTimeLockedCoins(std::vector<COutput> &vCoins, int64_t txLockTime)
 {
-    if (!(
-        (txLockTime <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
-        (txLockTime >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
-    ))
-        return false;
-    if (nLockTime > txLockTime)
+    // remove still timelocked coins
+    for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end();)
     {
-        return false;
+        int64_t nLockTime;
+        if (it->tx->vout[it->i].scriptPubKey.IsCheckLockTimeVerify(&nLockTime) && !TokelCheckLockTimeHelper(nLockTime, txLockTime))
+            it = vCoins.erase(it);
+        else
+            ++it;
     }
-    return true;
-}
-
-// sets unlocked state in the dest
-inline void SetTimeUnlocked(CTxDestination &dest, int64_t txLockTime)
-{
-    CCLTVID& cltv = boost::get<CCLTVID>(dest);
-    if (CheckLockTime(cltv.GetUnlockTime(), txLockTime))
-        cltv.SetUnlocked();
-}
-
+}*/
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/wallet_ismine.cpp
+++ b/src/wallet/wallet_ismine.cpp
@@ -26,6 +26,9 @@
 #include "script/standard.h"
 #include "cc/eval.h"
 
+#include "chain.h"
+extern CChain chainActive;
+
 #include <boost/foreach.hpp>
 
 using namespace std;
@@ -68,17 +71,9 @@ isminetype IsMineInner(const CKeyStore& keystore, const CScript& _scriptPubKey, 
     vector<valtype> vSolutions;
     txnouttype whichType;
     CScript scriptPubKey = _scriptPubKey;
-    
-    if (scriptPubKey.IsCheckLockTimeVerify())
-    {
-        uint8_t pushOp = scriptPubKey[0];
-        uint32_t scriptStart = pushOp + 3;
+    bool iscltv;
 
-        // continue with post CLTV script
-        scriptPubKey = CScript(scriptPubKey.size() > scriptStart ? scriptPubKey.begin() + scriptStart : scriptPubKey.end(), scriptPubKey.end());
-    }
-
-    if (!Solver(scriptPubKey, whichType, vSolutions)) {
+    if (!SolverCLTV(scriptPubKey, whichType, vSolutions, iscltv)) {
         if (keystore.HaveWatchOnly(scriptPubKey))
             return ISMINE_WATCH_ONLY;
         return ISMINE_NO;


### PR DESCRIPTION
txns with CLTV scriptPubKey are allowed as standard to mempool
daemon's wallet checks for CLTV inputs
listaddressgroupings rpc shows time-locked balances
NSPV bumped to v5: 
requestId field added to forth and back messages for correlation
first NSPV call must be getinfo to exchange versions
new NSPV error message added
script added to listunspent nspv messages
several protocol fixes and improvements 
more logging in NSPV code