### PR TITLE
Revert change to elide a warning that caused Solaris/Ubuntu21.10_Impish builds  to fail.

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,6 +4,7 @@ $(package)_version=1_72_0
 $(package)_download_path=https://github.com/KomodoPlatform/boost/releases/download/boost-1.72.0-kmd
 $(package)_sha256_hash=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
+$(package)_patches=fix-Solaris.patch 
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -27,7 +28,8 @@ endef
 
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam&& \
+  patch -p1 < $($(package)_patch_dir)/fix-Solaris.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/fix-Solaris.patch
+++ b/depends/patches/boost/fix-Solaris.patch
@@ -1,0 +1,22 @@
+From 74fb0a26099bc51d717f5f154b37231ce7df3e98 Mon Sep 17 00:00:00 2001
+From: Rob Boehne <robb@datalogics.com>
+Date: Wed, 20 Nov 2019 11:25:20 -0600
+Subject: [PATCH] Revert change to elide a warning that caused Solaris builds to fail.
+
+---
+ boost/thread/pthread/thread_data.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/boost/thread/pthread/thread_data.hpp b/boost/thread/pthread/thread_data.hpp
+index aefbeb43c..bc9b1367a 100644
+--- a/boost/thread/pthread/thread_data.hpp
++++ b/boost/thread/pthread/thread_data.hpp
+@@ -57,7 +57,7 @@ namespace boost
+ #else
+           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
+ #endif
+-#if PTHREAD_STACK_MIN > 0
++#ifdef PTHREAD_STACK_MIN
+           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
+ #endif
+           size = ((size+page_size-1)/page_size)*page_size;


### PR DESCRIPTION
https://github.com/boostorg/thread/commit/74fb0a26099bc51d717f5f154b37231ce7df3e98

